### PR TITLE
Register plug-in as Packer integration

### DIFF
--- a/.github/workflows/ensure-docs-compiled.yaml
+++ b/.github/workflows/ensure-docs-compiled.yaml
@@ -1,0 +1,22 @@
+name: Ensure Docs are Compiled
+on:
+  push:
+jobs:
+  ensure-docs-compiled:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎
+        uses: actions/checkout@v2
+      - uses: actions/setup-go@v4
+      - shell: bash
+        run: make build-docs
+      - shell: bash
+        run: |
+          if [[ -z "$(git status -s)" ]]; then
+            echo "OK"
+          else
+            echo "Docs have been updated, but the compiled docs have not been committed."
+            echo "Run 'make build-docs', and commit the result to resolve this error."
+            exit 1
+          fi
+

--- a/.github/workflows/notify-integration-release-via-manual.yaml
+++ b/.github/workflows/notify-integration-release-via-manual.yaml
@@ -1,0 +1,46 @@
+name: Notify Integration Release (Manual)
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "The release version (semver)"
+        default: 0.0.1
+        required: false
+      branch:
+        description: "A branch or SHA"
+        default: 'main'
+        required: false
+jobs:
+  notify-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout this repo
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        with:
+          ref: ${{ github.event.inputs.branch }}
+      # Ensure that Docs are Compiled
+      - uses: actions/setup-go@v4
+      - shell: bash
+        run: make build-docs
+      - shell: bash
+        run: |
+          if [[ -z "$(git status -s)" ]]; then
+            echo "OK"
+          else
+            echo "Docs have been updated, but the compiled docs have not been committed."
+            echo "Run 'make build-docs', and commit the result to resolve this error."
+            exit 1
+          fi
+      # Perform the Release
+      - name: Checkout integration-release-action
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        with:
+          repository: hashicorp/integration-release-action
+          path: ./integration-release-action
+      - name: Notify Release
+        uses: ./integration-release-action
+        with:
+          integration_identifier: 'packer/BrandonRomano/vultr'
+          release_version: ${{ github.event.inputs.version }}
+          release_sha: ${{ github.event.inputs.branch }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/notify-integration-release-via-manual.yaml
+++ b/.github/workflows/notify-integration-release-via-manual.yaml
@@ -1,10 +1,12 @@
+# Manual release workflow is used for deploying documentation updates
+# on the specified branch without making an official plugin release. 
 name: Notify Integration Release (Manual)
 on:
   workflow_dispatch:
     inputs:
       version:
         description: "The release version (semver)"
-        default: 0.0.1
+        default: 1.0.0
         required: false
       branch:
         description: "A branch or SHA"
@@ -15,32 +17,34 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout this repo
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
         with:
           ref: ${{ github.event.inputs.branch }}
       # Ensure that Docs are Compiled
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
       - shell: bash
-        run: make build-docs
+        run: make generate
       - shell: bash
         run: |
           if [[ -z "$(git status -s)" ]]; then
             echo "OK"
           else
             echo "Docs have been updated, but the compiled docs have not been committed."
-            echo "Run 'make build-docs', and commit the result to resolve this error."
+            echo "Run 'make generate', and commit the result to resolve this error."
             exit 1
           fi
       # Perform the Release
       - name: Checkout integration-release-action
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
         with:
           repository: hashicorp/integration-release-action
           path: ./integration-release-action
       - name: Notify Release
         uses: ./integration-release-action
         with:
-          integration_identifier: 'packer/BrandonRomano/vultr'
+          # The integration identifier will be used by the Packer team to register the integration
+          # the expected format is packer/<GitHub Org Name>/<plugin-name>
+          integration_identifier: "packer/hashicorp/scaffolding"
           release_version: ${{ github.event.inputs.version }}
           release_sha: ${{ github.event.inputs.branch }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/notify-integration-release-via-tag.yaml
+++ b/.github/workflows/notify-integration-release-via-tag.yaml
@@ -1,0 +1,40 @@
+name: Notify Integration Release (Tag)
+on:
+  push:
+    tags:
+      - '*.*.*'   # Proper releases
+      - '*.*.*-*' # Pre releases
+jobs:
+  notify-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout this repo
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        with:
+          ref: ${{ github.ref }}
+      # Ensure that Docs are Compiled
+      - uses: actions/setup-go@v4
+      - shell: bash
+        run: make build-docs
+      - shell: bash
+        run: |
+          if [[ -z "$(git status -s)" ]]; then
+            echo "OK"
+          else
+            echo "Docs have been updated, but the compiled docs have not been committed."
+            echo "Run 'make build-docs', and commit the result to resolve this error."
+            exit 1
+          fi
+      # Perform the Release
+      - name: Checkout integration-release-action
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        with:
+          repository: hashicorp/integration-release-action
+          path: ./integration-release-action
+      - name: Notify Release
+        uses: ./integration-release-action
+        with:
+          integration_identifier: 'packer/BrandonRomano/vultr'
+          release_version: ${{ github.ref_name }}
+          release_sha: ${{ github.ref }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/notify-integration-release-via-tag.yaml
+++ b/.github/workflows/notify-integration-release-via-tag.yaml
@@ -3,38 +3,52 @@ on:
   push:
     tags:
       - '*.*.*'   # Proper releases
-      - '*.*.*-*' # Pre releases
 jobs:
+  strip-version:
+    runs-on: ubuntu-latest
+    outputs:
+      packer-version: ${{ steps.strip.outputs.packer-version }}
+    steps:
+      - name: Strip leading v from version tag
+        id: strip
+        env:
+          REF: ${{ github.ref_name }}
+        run: |
+          echo "packer-version=$(echo "$REF" | sed -E 's/v?([0-9]+\.[0-9]+\.[0-9]+)/\1/')" >> "$GITHUB_OUTPUT"
   notify-release:
+    needs:
+      - strip-version
     runs-on: ubuntu-latest
     steps:
       - name: Checkout this repo
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
         with:
           ref: ${{ github.ref }}
       # Ensure that Docs are Compiled
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
       - shell: bash
-        run: make build-docs
+        run: make generate
       - shell: bash
         run: |
           if [[ -z "$(git status -s)" ]]; then
             echo "OK"
           else
             echo "Docs have been updated, but the compiled docs have not been committed."
-            echo "Run 'make build-docs', and commit the result to resolve this error."
+            echo "Run 'make generate', and commit the result to resolve this error."
             exit 1
           fi
       # Perform the Release
       - name: Checkout integration-release-action
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
         with:
           repository: hashicorp/integration-release-action
           path: ./integration-release-action
       - name: Notify Release
         uses: ./integration-release-action
         with:
-          integration_identifier: 'packer/BrandonRomano/vultr'
-          release_version: ${{ github.ref_name }}
+          # The integration identifier will be used by the Packer team to register the integration
+          # the expected format is packer/<GitHub Org Name>/<plugin-name>
+          integration_identifier: "packer/hashicorp/scaffolding"
+          release_version: ${{ needs.strip-version.outputs.packer-version }}
           release_sha: ${{ github.ref }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.web-docs/README.md
+++ b/.web-docs/README.md
@@ -1,0 +1,55 @@
+# Vultr Plugins
+
+The [Vultr](https://www.Vultr.com/) Packer plugin provides a builder for building images in
+Vultr.
+
+## Installation
+
+### Using pre-built releases
+
+#### Using the `packer init` command
+
+Starting from version 1.7, Packer supports a new `packer init` command allowing
+automatic installation of Packer plugins. Read the
+[Packer documentation](https://www.packer.io/docs/commands/init) for more information.
+
+To install this plugin, copy and paste this code into your Packer configuration .
+Then, run [`packer init`](https://www.packer.io/docs/commands/init).
+
+```hcl
+packer {
+  required_plugins {
+    vultr = {
+      version = ">= 2.5.0"
+      source  = "github.com/vultr/vultr"
+    }
+  }
+}
+```
+
+#### Manual installation
+
+You can find pre-built binary releases of the plugin [here](https://github.com/vultr/packer-plugin-vultr/releases).
+Once you have downloaded the latest archive corresponding to your target OS,
+uncompress it to retrieve the plugin binary file corresponding to your platform.
+To install the plugin, please follow the Packer documentation on
+[installing a plugin](https://www.packer.io/docs/extending/plugins/#installing-plugins).
+
+
+#### From Source
+
+If you prefer to build the plugin from its source code, clone the GitHub
+repository locally and run the command `go build` from the root
+directory. Upon successful compilation, a `packer-plugin-vultr` plugin
+binary file can be found in the root directory.
+To install the compiled plugin, please follow the official Packer documentation
+on [installing a plugin](https://www.packer.io/docs/extending/plugins/#installing-plugins).
+
+
+## Plugin Contents
+
+The Vultr plugin is intended as a starting point for creating Packer plugins, containing:
+
+### Builders
+
+- [builder](/docs/builders/vultr.mdx) - The builder takes a source image, runs any provisioning necessary on the image after launching it, then snapshots it into a reusable image. This reusable image can then be used as the foundation of new servers that are launched within Vultr.

--- a/.web-docs/README.md
+++ b/.web-docs/README.md
@@ -1,20 +1,9 @@
-# Vultr Plugins
-
 The [Vultr](https://www.Vultr.com/) Packer plugin provides a builder for building images in
 Vultr.
 
-## Installation
+### Installation
 
-### Using pre-built releases
-
-#### Using the `packer init` command
-
-Starting from version 1.7, Packer supports a new `packer init` command allowing
-automatic installation of Packer plugins. Read the
-[Packer documentation](https://www.packer.io/docs/commands/init) for more information.
-
-To install this plugin, copy and paste this code into your Packer configuration .
-Then, run [`packer init`](https://www.packer.io/docs/commands/init).
+To install this plugin, copy and paste this code into your Packer configuration, then run [`packer init`](https://www.packer.io/docs/commands/init).
 
 ```hcl
 packer {
@@ -27,29 +16,15 @@ packer {
 }
 ```
 
-#### Manual installation
+Alternatively, you can use `packer plugins install` to manage installation of this plugin.
 
-You can find pre-built binary releases of the plugin [here](https://github.com/vultr/packer-plugin-vultr/releases).
-Once you have downloaded the latest archive corresponding to your target OS,
-uncompress it to retrieve the plugin binary file corresponding to your platform.
-To install the plugin, please follow the Packer documentation on
-[installing a plugin](https://www.packer.io/docs/extending/plugins/#installing-plugins).
+```sh
+$ packer plugins install github.com/vultr/vultr
+```
 
 
-#### From Source
+### Components
 
-If you prefer to build the plugin from its source code, clone the GitHub
-repository locally and run the command `go build` from the root
-directory. Upon successful compilation, a `packer-plugin-vultr` plugin
-binary file can be found in the root directory.
-To install the compiled plugin, please follow the official Packer documentation
-on [installing a plugin](https://www.packer.io/docs/extending/plugins/#installing-plugins).
+#### Builders
 
-
-## Plugin Contents
-
-The Vultr plugin is intended as a starting point for creating Packer plugins, containing:
-
-### Builders
-
-- [builder](/docs/builders/vultr.mdx) - The builder takes a source image, runs any provisioning necessary on the image after launching it, then snapshots it into a reusable image. This reusable image can then be used as the foundation of new servers that are launched within Vultr.
+- [vultr](/packer/integrations/vultr/latest/components/builder/vultr) - The builder takes a source image, runs any provisioning necessary on the image after launching it, then snapshots it into a reusable image. This reusable image can then be used as the foundation of new servers that are launched within Vultr.

--- a/.web-docs/components/builder/vultr/README.md
+++ b/.web-docs/components/builder/vultr/README.md
@@ -1,16 +1,3 @@
----
-description: >
-    The vultr Packer builder is able to create new images for use with
-    Vultr. The builder takes a source image, runs any provisioning necessary
-    on the image after launching it, then snapshots it into a reusable image. This
-    reusable image can be then used as the foundation of new servers that are
-    launched within Vultr.
-page_title: Vultr - Builders
-nav_title: Vultr
----
-
-# Vultr
-
 Type: `vultr`
 
 The `vultr` Packer builder is able to create new images for use with

--- a/.web-docs/metadata.hcl
+++ b/.web-docs/metadata.hcl
@@ -1,0 +1,12 @@
+# For full specification on the configuration of this file visit:
+# https://github.com/hashicorp/integration-template#metadata-configuration
+integration {
+  name = "Vultr"
+  description = "TODO"
+  identifier = "packer/BrandonRomano/vultr"
+  component {
+    type = "builder"
+    name = "Vultr"
+    slug = "vultr"
+  }
+}

--- a/.web-docs/scripts/compile-to-webdocs.sh
+++ b/.web-docs/scripts/compile-to-webdocs.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+
+# Converts the folder name that the component documentation file
+# is stored in into the integration slug of the component.
+componentTypeFromFolderName() {
+    if [[ "$1" = "builders" ]]; then
+        echo "builder"
+    elif [[ "$1" = "provisioners" ]]; then
+        echo "provisioner"
+    elif [[ "$1" = "post-processors" ]]; then
+        echo "post-processor"
+    elif [[ "$1" = "datasources" ]]; then
+        echo "data-source"
+    else
+        echo ""
+    fi
+}
+
+# $1: The content to adjust links
+# $2: The organization of the integration
+rewriteLinks() {
+  local result="$1"
+  local organization="$2"
+
+  urlSegment="([^/]+)"
+  urlAnchor="(#[^/]+)"
+
+  # Rewrite Component Index Page links to the Integration root page.
+  #
+  #                    (\1)     (\2)      (\3)
+  # /packer/plugins/datasources/amazon#anchor-tag-->
+  # /packer/integrations/hashicorp/amazon#anchor-tag
+  local find="\(\/packer\/plugins\/$urlSegment\/$urlSegment$urlAnchor?\)"
+  local replace="\(\/packer\/integrations\/$organization\/\2\3\)"
+  result="$(echo "$result" | sed -E "s/$find/$replace/g")"
+
+
+  # Rewrite Component links to the Integration component page
+  #
+  #                    (\1)      (\2)       (\3)       (\4)
+  # /packer/plugins/datasources/amazon/parameterstore#anchor-tag -->
+  # /packer/integrations/{organization}/amazon/latest/components/datasources/parameterstore
+  local find="\(\/packer\/plugins\/$urlSegment\/$urlSegment\/$urlSegment$urlAnchor?\)"
+  local replace="\(\/packer\/integrations\/$organization\/\2\/latest\/components\/\1\/\3\4\)"
+  result="$(echo "$result" | sed -E "s/$find/$replace/g")"
+
+  # Rewrite the Component URL segment from the Packer Plugin format
+  # to the Integrations format
+  result="$(echo "$result" \
+      | sed "s/\/datasources\//\/data-source\//g" \
+      | sed "s/\/builders\//\/builder\//g" \
+      | sed "s/\/post-processors\//\/post-processor\//g" \
+      | sed "s/\/provisioners\//\/provisioner\//g" \
+  )"
+
+  echo "$result"
+}
+
+# $1: Docs Dir
+# $2: Web Docs Dir
+# $3: Component File
+# $4: The org of the integration
+processComponentFile() {
+    local docsDir="$1"
+    local webDocsDir="$2"
+    local componentFile="$3"
+
+    local escapedDocsDir="$(echo "$docsDir" | sed 's/\//\\\//g' | sed 's/\./\\\./g')"
+    local componentTypeAndSlug="$(echo "$componentFile" | sed "s/$escapedDocsDir\///g" | sed 's/\.mdx//g')"
+
+    # Parse out the Component Slug & Component Type
+    local componentSlug="$(echo "$componentTypeAndSlug" | cut -d'/' -f 2)"
+    local componentType="$(componentTypeFromFolderName "$(echo "$componentTypeAndSlug" | cut -d'/' -f 1)")"
+    if [[ "$componentType" = "" ]]; then
+        echo "Failed to process '$componentFile', unexpected folder name."
+        echo "Documentation for components must be stored in one of:"
+        echo "builders, provisioners, post-processors, datasources"
+        exit 1
+    fi
+
+
+    # Calculate the location of where this file will ultimately go
+    local webDocsFolder="$webDocsDir/components/$componentType/$componentSlug"
+    mkdir -p "$webDocsFolder"
+    local webDocsFile="$webDocsFolder/README.md"
+    local webDocsFileTmp="$webDocsFolder/README.md.tmp"
+
+    # Copy over the file to its webDocsFile location
+    cp "$componentFile" "$webDocsFile"
+
+    # Remove the Header
+    local lastMetadataLine="$(grep -n -m 2 '^\-\-\-' "$componentFile" | tail -n1 | cut -d':' -f1)"
+    cat "$webDocsFile" | tail -n +"$(($lastMetadataLine+2))"  > "$webDocsFileTmp"
+    mv "$webDocsFileTmp" "$webDocsFile"
+
+    # Remove the top H1, as this will be added automatically on the web
+    cat "$webDocsFile" | tail -n +3 > "$webDocsFileTmp"
+    mv "$webDocsFileTmp" "$webDocsFile"
+
+    # Rewrite Links
+    rewriteLinks "$(cat "$webDocsFile")" "$4" > "$webDocsFileTmp"
+    mv "$webDocsFileTmp" "$webDocsFile"
+}
+
+# Compiles the Packer SDC compiled docs folder down
+# to a integrations-compliant folder (web docs)
+#
+# $1: The directory of the plugin
+# $2: The directory of the SDC compiled docs files
+# $3: The output directory to place the web-docs files
+# $4: The org of the integration
+compileWebDocs() {
+  local docsDir="$1/$2"
+  local webDocsDir="$1/$3"
+
+  echo "Compiling MDX docs in '$2' to Markdown in '$3'..."
+  # Create the web-docs directory if it hasn't already been created
+  mkdir -p "$webDocsDir"
+
+  # Copy the README over
+  cp "$docsDir/README.md" "$webDocsDir/README.md"
+
+  # Process all MDX component files (exclude index files, which are unsupported)
+  for file in $(find "$docsDir" | grep "$docsDir/.*/.*\.mdx" | grep --invert-match "index.mdx"); do
+    processComponentFile "$docsDir" "$webDocsDir" "$file" "$4"
+  done
+}
+
+compileWebDocs "$1" "$2" "$3" "$4"

--- a/Makefile
+++ b/Makefile
@@ -43,3 +43,9 @@ ci-release-docs: install-packer-sdc
 
 plugin-check: install-packer-sdc build-binary
 	@packer-sdc plugin-check ${BINARY}
+
+build-docs: install-packer-sdc
+	@if [ -d ".docs" ]; then rm -r ".docs"; fi
+	@packer-sdc renderdocs -src "docs" -partials docs-partials/ -dst ".docs/"
+	@./.web-docs/scripts/compile-to-webdocs.sh "." ".docs" ".web-docs" "BrandonRomano"
+	@rm -r ".docs"

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,20 +1,9 @@
-# Vultr Plugins
-
 The [Vultr](https://www.Vultr.com/) Packer plugin provides a builder for building images in
 Vultr.
 
-## Installation
+### Installation
 
-### Using pre-built releases
-
-#### Using the `packer init` command
-
-Starting from version 1.7, Packer supports a new `packer init` command allowing
-automatic installation of Packer plugins. Read the
-[Packer documentation](https://www.packer.io/docs/commands/init) for more information.
-
-To install this plugin, copy and paste this code into your Packer configuration .
-Then, run [`packer init`](https://www.packer.io/docs/commands/init).
+To install this plugin, copy and paste this code into your Packer configuration, then run [`packer init`](https://www.packer.io/docs/commands/init).
 
 ```hcl
 packer {
@@ -27,29 +16,15 @@ packer {
 }
 ```
 
-#### Manual installation
+Alternatively, you can use `packer plugins install` to manage installation of this plugin.
 
-You can find pre-built binary releases of the plugin [here](https://github.com/vultr/packer-plugin-vultr/releases).
-Once you have downloaded the latest archive corresponding to your target OS,
-uncompress it to retrieve the plugin binary file corresponding to your platform.
-To install the plugin, please follow the Packer documentation on
-[installing a plugin](https://www.packer.io/docs/extending/plugins/#installing-plugins).
+```sh
+$ packer plugins install github.com/vultr/vultr
+```
 
 
-#### From Source
+### Components
 
-If you prefer to build the plugin from its source code, clone the GitHub
-repository locally and run the command `go build` from the root
-directory. Upon successful compilation, a `packer-plugin-vultr` plugin
-binary file can be found in the root directory.
-To install the compiled plugin, please follow the official Packer documentation
-on [installing a plugin](https://www.packer.io/docs/extending/plugins/#installing-plugins).
+#### Builders
 
-
-## Plugin Contents
-
-The Vultr plugin is intended as a starting point for creating Packer plugins, containing:
-
-### Builders
-
-- [builder](/docs/builders/vultr.mdx) - The builder takes a source image, runs any provisioning necessary on the image after launching it, then snapshots it into a reusable image. This reusable image can then be used as the foundation of new servers that are launched within Vultr.
+- [vultr](/packer/integrations/vultr/latest/components/builder/vultr) - The builder takes a source image, runs any provisioning necessary on the image after launching it, then snapshots it into a reusable image. This reusable image can then be used as the foundation of new servers that are launched within Vultr.


### PR DESCRIPTION
:wave: fellow Packer maintainer working on migrating your plugin to the Packer integration framework.

This change takes the necessary steps to register this plugin as an official Packer integration.
Integrations can be found on the Packer integration portal at https://developer.hashicorp.com/packer/integrations.

---

The pull-request consists of the following changes:

- Adds controlling, metadata file, `metadata.hcl` for registering the plug-in and it components as integrations.
Details on the contents, along with a description of the attributes, can be found at https://github.com/hashicorp/integration-template.
- Adds the GitHub action workflows for triggering manual and automatic integration updates.
- Restructures the plug-in documentation to match the expected format of the integration framework.
- Adds a `.web-docs` directory for serving the fully render documentation as the integration docs.
- Adds the build-docs make target `make build-docs` for syncing changes to the `docs` directory to the `.web-docs` directory.

Changes to the integration docs can be made at plugin release via the `notify-integration-release-via-tag` workflow or
manually by running the `notify-integration-release-via-manual` workflow.

Details on how the Integration framework pipeline works can be found at https://github.com/hashicorp/packer/pull/12702

### TODOs
- [x] Open pull-request against external plugin.
- [ ] Update integration description [`.web-docs/metadata.hcl`](.web-docs/metadata.hcl).
- [ ] Packer team open internal pull-request to enable integration.
- [ ] Review plugin integration on Packer integration portal .... Iterate
