### PR TITLE
Update Vultr Packer documentation to reflect new `tags` attribute

### DIFF
--- a/docs/builders/vultr.mdx
+++ b/docs/builders/vultr.mdx
@@ -64,7 +64,7 @@ to use it or delete it.
 
 -   `hostname` (string) - Hostname to assign to this server.
 
--   `tag` (string) - The tag to assign to this server.
+-   `tags` (array of string) - The tags to assign to this server.
 
 -   `state_timeout` (string) - A duration to wait for the instance to boot, or a snapshot to be taken. Must be a string in [golang Duration-parsable format](https://golang.org/pkg/time/#ParseDuration), like "10m" or "30s". Defaults to `10m`
 


### PR DESCRIPTION
This was changed in
https://github.com/vultr/packer-plugin-vultr/commit/2e4cdb945098b0a1b24ba588e0d7b74d9707e6fd

## Description

This change fixes the documentation to use the new `tags` attribute.

## Related Issues

This was introduced in #324.

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
