### PR TITLE
Fix GoReleaser archive naming for Packer plugin assets

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -55,6 +55,7 @@ archives:
     formats: ["zip"]
     files:
       - none*
+    name_template: '{{ .ProjectName }}_v{{ .Version }}_{{ .Env.API_VERSION }}_{{ .Os }}_{{ .Arch }}'
 checksum:
   name_template: '{{ .ProjectName }}_v{{ .Version }}_SHA256SUMS'
   algorithm: sha256


### PR DESCRIPTION
## Description
Reintroduced `name_template:` in `.goreleaser.yml` to fix the naming issues in the v2.6.4 release

## Related Issues
Fixes: #388 

### Checklist:

* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
